### PR TITLE
fixed the profile styling for homepage to fix footer

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -15,8 +15,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 40%;
-  max-width: 200px;
+  width: 200px;
 }
 .footer-links a {
   color: white;

--- a/app/assets/stylesheets/components/_profile-card.scss
+++ b/app/assets/stylesheets/components/_profile-card.scss
@@ -1,10 +1,24 @@
 .all-profiles {
   text-align: center;
   margin-bottom: 60px;
+  overflow: hidden;
+
+  ::-webkit-scrollbar {
+  display: none;
+  }
 }
 
 .profile-info {
 
+}
+
+.profile-card {
+  width:100%;
+  overflow: hidden;
+  margin-left :0;
+  margin-right :0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .card-controls {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="footer">
   <div class="footer-links">
     <%= link_to root_path  do %>
-      🪢
+      <i class="fas fa-home"></i>
     <% end %>
     <%= link_to ties_path  do %>
       <i class="fas fa-user-friends"></i>


### PR DESCRIPTION
Fixed the .all_profile class in profile_card.scss so that no overflow occurs on the homepage which for some reason pushed the footer down.

Spaced the left three footer icons within 200px frame, allowing only the avatar pic to move.

Home button now is a home icon not a emoji