### PR TITLE
Chat and chat_list style 

### DIFF
--- a/app/assets/stylesheets/components/_message-container.scss
+++ b/app/assets/stylesheets/components/_message-container.scss
@@ -4,6 +4,19 @@
 }
 
 .outgoing {
-  background-color: #79c7c5;
+  background-color: #59C0B9;
   border-radius: 15px;
+}
+
+.message-header {
+  background-color: #292F36;
+}
+
+.your-tie-image-box {
+  width: 50px;
+  min-width: 50px; // DO NOT REMOVE!. It has been added to prevent image from becoming an ellipse when resizing screen.
+  height: 50px;
+  border-radius: 50%;
+  object-fit: cover;
+  overflow: hidden;
 }

--- a/app/controllers/ties_controller.rb
+++ b/app/controllers/ties_controller.rb
@@ -12,12 +12,6 @@ class TiesController < ApplicationController
       end
       @lastmessage = Message.where(tie_id: tie.id).last
       @users.push([User.find(@user_id), @lastmessage, tie.id])
-
-      if current_user.id == tie.user1_id
-        @my_messages = Message.where(tie_id: tie).where(user_id: tie.user1_id)
-      else
-        @my_messages = Message.where(tie_id: tie).where(user_id: tie.user2_id)
-      end
     end
   end
 
@@ -44,8 +38,10 @@ class TiesController < ApplicationController
 
     # selecting your tie's messages as "seen" when open a chat
     if current_user.id == @tie.user1_id
+      @your_tie = User.find(@tie.user2_id)
       @your_tie_messages = Message.where(tie_id: @tie).where(user_id: @tie.user2_id)
     else
+      @your_tie = User.find(@tie.user1_id)
       @your_tie_messages = Message.where(tie_id: @tie).where(user_id: @tie.user1_id)
     end
     @your_tie_messages.update_all "seen = true"

--- a/app/controllers/ties_controller.rb
+++ b/app/controllers/ties_controller.rb
@@ -10,9 +10,14 @@ class TiesController < ApplicationController
       elsif current_user.id == tie.user2_id
         @user_id = tie.user1_id
       end
-      @tie = tie.id
       @lastmessage = Message.where(tie_id: tie.id).last
-      @users.push([User.find(@user_id), @lastmessage, @tie])
+      @users.push([User.find(@user_id), @lastmessage, tie.id])
+
+      if current_user.id == tie.user1_id
+        @my_messages = Message.where(tie_id: tie).where(user_id: tie.user1_id)
+      else
+        @my_messages = Message.where(tie_id: tie).where(user_id: tie.user2_id)
+      end
     end
   end
 
@@ -33,8 +38,16 @@ class TiesController < ApplicationController
   end
 
   def show
+    # creating a new message
     @tie = Tie.find(params[:id])
     @message = Message.new
-  end
 
+    # selecting your tie's messages as "seen" when open a chat
+    if current_user.id == @tie.user1_id
+      @your_tie_messages = Message.where(tie_id: @tie).where(user_id: @tie.user2_id)
+    else
+      @your_tie_messages = Message.where(tie_id: @tie).where(user_id: @tie.user1_id)
+    end
+    @your_tie_messages.update_all "seen = true"
+  end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -3,7 +3,7 @@
   <% if author %>
     <div class="d-flex">
       <div class="col-4"></div>
-      <div class="col-8 my-1 pt-3 incoming text-white text-right">
+      <div class="col-8 my-1 pt-3 outgoing text-white text-right">
         <p><%= message.content %></p>
         <i class="author text-muted">
           <small><%= message.created_at.in_time_zone('Melbourne').strftime("%l:%M%p") %></small>
@@ -12,7 +12,7 @@
     </div>
   <% else %>
     <div class="d-flex">
-      <div class="col-8 my-1 pt-3 outgoing text-white">
+      <div class="col-8 my-1 pt-3 incoming text-white">
         <p><%= message.content %></p>
         <i class="author text-muted">
           <small><%= message.created_at.in_time_zone('Melbourne').strftime("%l:%M%p") %></small>

--- a/app/views/ties/chat_list.html.erb
+++ b/app/views/ties/chat_list.html.erb
@@ -29,7 +29,7 @@
               <!-- tie's last message -->
               <!-- Make unseen messages bold -->
               <div class="m-2">
-                <% if user[1].seen %>
+                <% if user[1].seen || ( user[1].user_id == current_user.id ) %>
                   <%= user[1].content %>
                 <% else %>
                   <strong> <%= user[1].content.truncate(27) %> </strong>

--- a/app/views/ties/chat_list.html.erb
+++ b/app/views/ties/chat_list.html.erb
@@ -30,7 +30,7 @@
               <!-- Make unseen messages bold -->
               <div class="m-2">
                 <% if user[1].seen || ( user[1].user_id == current_user.id ) %>
-                  <%= user[1].content %>
+                  <%= user[1].content.truncate(27) %>
                 <% else %>
                   <strong> <%= user[1].content.truncate(27) %> </strong>
                 <% end %>

--- a/app/views/ties/show.html.erb
+++ b/app/views/ties/show.html.erb
@@ -1,7 +1,29 @@
 <!-- app/views/chatrooms/show.html.erb -->
 <!-- <h1>The chat between <%= @tie.user1.first_name %> and <%= @tie.user2.first_name %> </h1> -->
 <div>
-  <div id="messages" style="margin-bottom: 155px" data-tie-id="<%= @tie.id %>" data-current-user-id = "<%= current_user.id %>">
+  <div class="message-header fixed-top text-white d-flex align-items-center">
+    <!-- back button to chat_list -->
+    <div class="p-2">
+      <%= link_to chat_list_ties_path do %>
+        <i class="fas fa-chevron-left"></i>
+      <% end %>
+    </div>
+    <!-- tie's avatar -->
+    <div class="p-2">
+      <% if @your_tie.photos.attached? %>
+        <div class="your-tie-image-box"> <%= cl_image_tag @your_tie.photos.first.key, width: 100, height: 100, crop: :thumb %> </div>
+      <% else %>
+        <div class="your-tie-image-box" style="background-image: url('<%= image_path("person_with_hat.jpg", width: 100, height: 100, crop: :thumb) %>')"> </div>
+      <% end %>
+    </div>
+    <!-- tie's first and last name -->
+    <div>
+      <h2> <%= @your_tie.first_name %> <%= @your_tie.last_name %>  </h2>
+    </div>
+  </div>
+
+
+  <div id="messages" style="margin-bottom: 120px; margin-top: 70px" data-tie-id="<%= @tie.id %>" data-current-user-id = "<%= current_user.id %>">
     <% @tie.messages.order(:created_at).each do |message| %>
       <%= render partial: "messages/message", locals: {message: message, author: message.user == current_user} %>
     <% end %>
@@ -9,8 +31,10 @@
 
   <div class="fixed-bottom" style="background-color: white; padding-bottom: 53px; z-index: auto">
     <%= simple_form_for [ @tie, @message ], remote: true do |f| %>
-      <%= f.input :content, label: false, placeholder: "Message"%>
-      <%= f.button :submit, class: "primary-button"%>
+    <div class="d-flex align-items-cente">
+      <div class="col-9"><%= f.input :content, label: false, placeholder: "Message"%></div>
+      <div><%= f.button :submit, "Send" , class: "primary-button"%></div>
+    </div>
     <% end %>
   </div>
 </div>

--- a/app/views/ties/show.html.erb
+++ b/app/views/ties/show.html.erb
@@ -1,8 +1,8 @@
 <!-- app/views/chatrooms/show.html.erb -->
 <!-- <h1>The chat between <%= @tie.user1.first_name %> and <%= @tie.user2.first_name %> </h1> -->
-<div">
+<div>
   <div id="messages" style="margin-bottom: 155px" data-tie-id="<%= @tie.id %>" data-current-user-id = "<%= current_user.id %>">
-    <% @tie.messages.each do |message| %>
+    <% @tie.messages.order(:created_at).each do |message| %>
       <%= render partial: "messages/message", locals: {message: message, author: message.user == current_user} %>
     <% end %>
   </div>


### PR DESCRIPTION
Ties#show (private messages)

1. Added a header with tie's avatar, name, and a back button
2. Changed the simple form
3. Messages are updated to "seen" when the page is open

Ties#Chat_list (list of chats)

1. Messages that the current_user sent and seen messages are displayed as normal text. Unseen messages are in **bold.** 

![Screen Shot 2021-08-05 at 10 00 09 pm (2)](https://user-images.githubusercontent.com/79692926/128346487-52811314-0b7f-4501-95a6-6afaee77a390.png)
